### PR TITLE
add missing identifier for chartboost

### DIFF
--- a/FairBid/chartboost.plist.xml
+++ b/FairBid/chartboost.plist.xml
@@ -440,6 +440,10 @@
 				<key>SKAdNetworkIdentifier</key>
 				<string>8r8llnkz5a.skadnetwork</string>
 			</dict>
+			<dict>
+				<key>SKAdNetworkIdentifier</key>
+				<string>252b5q8x7y.skadnetwork</string>
+			</dict>
 		</array>
 	</dict>
 </plist>


### PR DESCRIPTION
Got this report
![image](https://github.com/fyber-engineering/SKAdNetworks/assets/26203577/6b43e536-492f-4edf-afd0-ce881aabb340)
